### PR TITLE
Fixed add product

### DIFF
--- a/components/product/form.js
+++ b/components/product/form.js
@@ -1,58 +1,38 @@
-import { useEffect, useState } from 'react'
-import { getCategories } from '../../data/products'
-import CardLayout from '../card-layout'
-import { Textarea, Select, Input } from '../form-elements'
+import { useEffect, useState } from "react";
+import { getCategories } from "../../data/products";
+import CardLayout from "../card-layout";
+import { Textarea, Select, Input } from "../form-elements";
 
 export default function ProductForm({ formEl, saveEvent, title, router }) {
-  const [categories, setCategories] = useState([])
+  const [categories, setCategories] = useState([]);
 
-
-useEffect(() => {
-  if (token) {
-    getCategories().then(catData => setCategories(catData))
-  }
-}, [token])
-
-
-
+  useEffect(() => {
+    getCategories().then((catData) => setCategories(catData));
+  }, []);
 
   return (
     <CardLayout title={title}>
       <form ref={formEl}>
-        <Input
-          id="name"
-          label="Name"
-        />
-        <Textarea
-          id="description"
-          label="Description"
-        />
+        <Input id="name" label="Name" />
+        <Textarea id="description" label="Description" />
         <Select
           id="category"
           options={categories}
           label="Category"
           title="Select a Category"
         />
-        <Input
-          id="price"
-          label="Price"
-        />
-        <Input
-          id="location"
-          label="Location"
-        />
-        <Input
-          id="quantity"
-          label="Quantity"
-          type="number"
-        />
+        <Input id="price" label="Price" />
+        <Input id="location" label="Location" />
+        <Input id="quantity" label="Quantity" type="number" />
       </form>
       <>
-        <a className="card-footer-item" onClick={saveEvent}>Save</a>
-        <a className="card-footer-item" onClick={() => router.back()}>Cancel</a>
+        <a className="card-footer-item" onClick={saveEvent}>
+          Save
+        </a>
+        <a className="card-footer-item" onClick={() => router.back()}>
+          Cancel
+        </a>
       </>
     </CardLayout>
-  )
+  );
 }
-
-

--- a/pages/products/new.js
+++ b/pages/products/new.js
@@ -1,25 +1,26 @@
-import { useRouter } from 'next/router'
-import { useRef } from 'react'
-import Layout from '../../components/layout'
-import Navbar from '../../components/navbar'
-import { addProduct } from '../../data/products'
-import ProductForm from '../../components/product/form'
+import { useRouter } from "next/router";
+import { useRef } from "react";
+import Layout from "../../components/layout";
+import Navbar from "../../components/navbar";
+import { addProduct } from "../../data/products";
+import ProductForm from "../../components/product/form";
 export default function NewProduct() {
-  const formEl = useRef()
-  const router = useRouter()
+  const formEl = useRef();
+  const router = useRouter();
 
   const saveProduct = () => {
-    const { name, description, price, category, location, quantity  } = formEl.current
+    const { name, description, price, category, location, quantity } =
+      formEl.current;
     const product = {
       name: name.value,
       description: description.value,
       price: price.value,
-      categoryId: category.value,
+      category_id: parseInt(category.value),
       location: location.value,
-      quantity: quantity.value
-    }
-    addProduct(product).then((res) => router.push(`/products/${res.id}`))
-  }
+      quantity: quantity.value,
+    };
+    addProduct(product).then((res) => router.push(`/products/${res.id}`));
+  };
 
   return (
     <ProductForm
@@ -28,7 +29,7 @@ export default function NewProduct() {
       title="Add a new product"
       router={router}
     ></ProductForm>
-  )
+  );
 }
 
 NewProduct.getLayout = function getLayout(page) {
@@ -37,5 +38,5 @@ NewProduct.getLayout = function getLayout(page) {
       <Navbar />
       {page}
     </Layout>
-  )
-}
+  );
+};

--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -311,7 +311,7 @@ export default function StoreDetail() {
                     {isOwner && (
                       <button
                         className="button is-primary is-medium"
-                        onClick={() => router.push("/products/create")}
+                        onClick={() => router.push("/products/new")}
                       >
                         <span className="icon">
                           <i className="fas fa-plus"></i>


### PR DESCRIPTION
Fixed Add Product page to submit correct category key ("category_id" and parse the category string instead of "categoryId") 

Fixed route on "Add product" button  from 'store/id' to route to products/new instead of products/create. Products/create does not exist. 